### PR TITLE
  Add PhoneNumber params at SNS publish

### DIFF
--- a/src/Aws/Sns/Resources/sns-2010-03-31.php
+++ b/src/Aws/Sns/Resources/sns-2010-03-31.php
@@ -871,6 +871,10 @@ return array (
                     'type' => 'string',
                     'location' => 'aws.query',
                 ),
+                'PhoneNumber' => array( // new parameter
+                    'type' => 'string',
+                    'location' => 'aws.query',
+                ),
                 'Message' => array(
                     'required' => true,
                     'type' => 'string',


### PR DESCRIPTION
RC api does not support latest version of AWS-SDK
To use SNS SMS publish function, I add PhoneNumber params at /src/Aws/Sns/Resources/sns-2010-03-31.php